### PR TITLE
Parsing a JWT without signature fails with JSON::JWS::InvalidFormat: Unknown Signature Algorithm

### DIFF
--- a/lib/json/jwt.rb
+++ b/lib/json/jwt.rb
@@ -29,7 +29,7 @@ module JSON
 
     def verify(signature_base_string, signature = '', public_key_or_secret = nil)
       case header[:alg]
-      when :none
+      when :none, "none"
         signature == '' or raise VerificationFailed
       else
         JWS.new(self).verify(signature_base_string, signature, public_key_or_secret)
@@ -58,7 +58,7 @@ module JSON
     class << self
       def decode(jwt_string, public_key_or_secret = nil)
         raise InvalidFormat.new('Invalid JWT Format. JWT should include 2 dots.') unless jwt_string.count('.') == 2
-        header, claims, signature = jwt_string.split('.').collect do |segment|
+        header, claims, signature = jwt_string.split('.', 3).collect do |segment|
           UrlSafeBase64.decode64 segment.to_s
         end
         signature_base_string = jwt_string.split('.')[0,2].join('.')

--- a/spec/json/jwt_spec.rb
+++ b/spec/json/jwt_spec.rb
@@ -64,4 +64,14 @@ describe JSON::JWT do
       end
     end
   end
+
+  describe '.decode' do
+    context 'when not signed nor encrypted' do
+      context 'no signature given' do
+        it do
+          JSON::JWT.decode(jwt.to_s).should == jwt.stringify_keys
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
jwt.rb expects header[:alg] to be :none, but we get "none" from JSON.parse.
