### PR TITLE
Use OpenSSL::Digest instead of OpenSSL::Digest::Digest

### DIFF
--- a/lib/json/jwe.rb
+++ b/lib/json/jwe.rb
@@ -118,7 +118,7 @@ module JSON
     end
 
     def sha_digest
-      OpenSSL::Digest::Digest.new "SHA#{sha_size}"
+      OpenSSL::Digest.new "SHA#{sha_size}"
     end
 
     def derive_encryption_and_mac_keys_cbc!

--- a/lib/json/jws.rb
+++ b/lib/json/jws.rb
@@ -24,7 +24,7 @@ module JSON
     private
 
     def digest
-      OpenSSL::Digest::Digest.new "SHA#{algorithm.to_s[2, 3]}"
+      OpenSSL::Digest.new "SHA#{algorithm.to_s[2, 3]}"
     end
 
     def hmac?


### PR DESCRIPTION
Per ruby/ruby#446 OpenSSL::Digest::Digest is now deprecated and has
deprecation warnings.
