### PR TITLE
Relax OpenSSL version requirements for GCM

### DIFF
--- a/lib/json/jwe.rb
+++ b/lib/json/jwe.rb
@@ -69,7 +69,7 @@ module JSON
 
     def gcm_supported?
       RUBY_VERSION >= '2.0.0' && (OpenSSL::OPENSSL_VERSION >= 'OpenSSL 1.0.1c' ||
-        OpenSSL::SSL_VERSION == 'OpenSSL 1.0.1 14 Mar 2012')
+        OpenSSL::OPENSSL_VERSION == 'OpenSSL 1.0.1 14 Mar 2012')
     end
 
     def gcm?

--- a/lib/json/jwe.rb
+++ b/lib/json/jwe.rb
@@ -68,7 +68,8 @@ module JSON
     # common
 
     def gcm_supported?
-      RUBY_VERSION >= '2.0.0' && OpenSSL::OPENSSL_VERSION >= 'OpenSSL 1.0.1c'
+      RUBY_VERSION >= '2.0.0' && (OpenSSL::OPENSSL_VERSION >= 'OpenSSL 1.0.1c' ||
+        OpenSSL::SSL_VERSION == 'OpenSSL 1.0.1 14 Mar 2012')
     end
 
     def gcm?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,8 @@ RSpec.configure do |config|
 end
 
 def gcm_supported?
-  RUBY_VERSION >= '2.0.0' && OpenSSL::OPENSSL_VERSION >= 'OpenSSL 1.0.1c'
+  RUBY_VERSION >= '2.0.0' && (OpenSSL::OPENSSL_VERSION >= 'OpenSSL 1.0.1c' ||
+      OpenSSL::OPENSSL_VERSION == 'OpenSSL 1.0.1 14 Mar 2012')
 end
 
 require 'helpers/sign_key_fixture_helper'


### PR DESCRIPTION
GCM is supported by this version of OpenSSL (e.g. see [here](http://h20564.www2.hp.com/hpsc/doc/public/display?docId=mmr_kc-0112566)), but this doesn't seem to be reflected in the gem.