### PR TITLE
Fix specs when nimbus_jwe is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Gemfile.lock
 
 ## PROJECT::SPECIFIC
 .class
+
+## BUNDLER
+.bundle

--- a/spec/helpers/nimbus_spec_helper.rb
+++ b/spec/helpers/nimbus_spec_helper.rb
@@ -5,12 +5,11 @@ module NimbusSpecHelper
     nimbus_path = File.expand_path(
       File.join(
         File.dirname(__FILE__),
-        'json-jwt-nimbus'
+        'json-jwt-nimbus',
+        'nimbus_jwe'
       )
     )
-    if File.exist? nimbus_path
-      require File.join(nimbus_path, 'nimbus_jwe')
-    end
+    require nimbus_path if File.exist? nimbus_path
   end
 
   def nimbus_available?


### PR DESCRIPTION
This was failing for me locally because I had the directory but nothing in it.

Also adds `.bundle` to `.gitignore`.