### PR TITLE
Remove ActiveSupport

### DIFF
--- a/json-jwt.gemspec
+++ b/json-jwt.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
   gem.add_runtime_dependency "multi_json", ">= 1.3"
+  gem.add_runtime_dependency "hashery", "~> 2.0"
   gem.add_runtime_dependency "url_safe_base64"
-  gem.add_runtime_dependency "activesupport"
   gem.add_runtime_dependency "bindata"
   gem.add_runtime_dependency "securecompare"
   gem.add_development_dependency "rake", ">= 0.8"

--- a/lib/json/jose.rb
+++ b/lib/json/jose.rb
@@ -2,21 +2,23 @@ require 'securecompare'
 
 module JSON
   module JOSE
-    extend ActiveSupport::Concern
+    def self.included(base)
+      base.class_eval do
+        extend ClassMethods
+        include SecureCompare
 
-    included do
-      extend ClassMethods
-      include SecureCompare
-      register_header_keys :alg, :jku, :jwk, :x5u, :x5t, :x5c, :kid, :typ, :cty, :crit
-      alias_method :algorithm, :alg
+        register_header_keys :alg, :jku, :jwk, :x5u, :x5t, :x5c, :kid, :typ, :cty, :crit
+        alias_method :algorithm, :alg
 
-      attr_accessor :header
-      def header
-        @header ||= {}
-      end
+        attr_accessor :header
 
-      def content_type
-        @content_type ||= 'application/jose'
+        def header
+          @header ||= {}
+        end
+
+        def content_type
+          @content_type ||= 'application/jose'
+        end
       end
     end
 
@@ -25,9 +27,14 @@ module JSON
       when JSON::JWK
         key.to_key
       when JSON::JWK::Set
-        key.detect do |jwk|
+        jwk = key.detect do |jwk|
           jwk[:kid] && jwk[:kid] == kid
-        end.try(:to_key) or raise JWK::Set::KidNotFound
+        end
+        if jwk
+          jwk.to_key
+        else
+          raise JWK::Set::KidNotFound
+        end
       else
         key
       end

--- a/lib/json/jwk/set.rb
+++ b/lib/json/jwk/set.rb
@@ -4,7 +4,7 @@ module JSON
       class KidNotFound < JWT::Exception; end
 
       def initialize(*jwks)
-        jwks = if jwks.first.is_a?(Hash) && (keys = jwks.first.with_indifferent_access[:keys])
+        jwks = if jwks.first.is_a?(Hash) && (keys = Hashery::KeyHash[jwks.first][:keys])
           keys
         else
           jwks

--- a/spec/interop/with_jsrsasign_spec.rb
+++ b/spec/interop/with_jsrsasign_spec.rb
@@ -4,21 +4,21 @@ describe 'interop' do
   describe 'with jsrsasign' do
     context 'JWS' do
       let(:public_key) do
-        pem = <<-PEM.strip_heredoc
-          -----BEGIN PUBLIC KEY-----
-          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoBUyo8CQAFPeYPvv78ylh5MwFZjT
-          CLQeb042TjiMJxG+9DLFmRSMlBQ9T/RsLLc+PmpB1+7yPAR+oR5gZn3kJQ==
-          -----END PUBLIC KEY-----
+        pem = <<-PEM
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoBUyo8CQAFPeYPvv78ylh5MwFZjT
+CLQeb042TjiMJxG+9DLFmRSMlBQ9T/RsLLc+PmpB1+7yPAR+oR5gZn3kJQ==
+-----END PUBLIC KEY-----
         PEM
         OpenSSL::PKey::EC.new pem
       end
       let(:private_key) do
-        pem = <<-PEM.strip_heredoc
-          -----BEGIN PRIVATE KEY-----
-          MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgEbVzfPnZPxfAyxqE
-          ZV05laAoJAl+/6Xt2O4mOB611sOhRANCAASgFTKjwJAAU95g++/vzKWHkzAVmNMI
-          tB5vTjZOOIwnEb70MsWZFIyUFD1P9Gwstz4+akHX7vI8BH6hHmBmfeQl
-          -----END PRIVATE KEY-----
+        pem = <<-PEM
+-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgEbVzfPnZPxfAyxqE
+ZV05laAoJAl+/6Xt2O4mOB611sOhRANCAASgFTKjwJAAU95g++/vzKWHkzAVmNMI
+tB5vTjZOOIwnEb70MsWZFIyUFD1P9Gwstz4+akHX7vI8BH6hHmBmfeQl
+-----END PRIVATE KEY-----
         PEM
         OpenSSL::PKey::EC.new pem
       end

--- a/spec/json/jwk_spec.rb
+++ b/spec/json/jwk_spec.rb
@@ -17,7 +17,7 @@ describe JSON::JWK do
       it { should be_instance_of JSON::JWK }
       describe 'kid' do
         subject { jwk[:kid] }
-        it { should be_blank }
+        it { should be_nil }
       end
     end
 

--- a/spec/json/jwt_spec.rb
+++ b/spec/json/jwt_spec.rb
@@ -9,11 +9,11 @@ describe JSON::JWT do
     jws
   end
   let(:claims) do
-    {
+    Hashery::KeyHash[
       iss: 'joe',
       exp: 1300819380,
       'http://example.com/is_root' => true
-    }.with_indifferent_access
+    ]
   end
   let(:no_signed) do
     'eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJpc3MiOiJqb2UiLCJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.'
@@ -66,7 +66,7 @@ describe JSON::JWT do
       let(:key) { private_key }
       it 'should not set kid header automatically' do
         jws = jwt.sign(key, :RS256)
-        jws.kid.should be_blank
+        jws.kid.should be_nil
       end
     end
 
@@ -74,7 +74,7 @@ describe JSON::JWT do
       let(:key) { JSON::JWK.new private_key }
       it 'should set kid header automatically' do
         jws = jwt.sign(key, :RS256)
-        jwt.kid.should be_blank
+        jwt.kid.should be_nil
         jws.kid.should == key[:kid]
       end
     end
@@ -103,7 +103,7 @@ describe JSON::JWT do
       let(:key) { shared_key }
       it 'should not set kid header automatically' do
         jwe = jwt.encrypt(key, :dir)
-        jwe.kid.should be_blank
+        jwe.kid.should be_nil
       end
     end
 
@@ -111,7 +111,7 @@ describe JSON::JWT do
       let(:key) { JSON::JWK.new shared_key }
       it 'should set kid header automatically' do
         jwe = jwt.encrypt(key, :dir)
-        jwt.kid.should be_blank
+        jwt.kid.should be_nil
         jwe.kid.should == key[:kid]
       end
     end


### PR DESCRIPTION
Depend on hashery for a AS::HWIA replacement. Replace all other
usages with core behavior.

ActiveSupport is an unnecessary big dependency. `json-jwt` is very useful outside Rails contexts, too. Bloating the dependency tree of every project directly or indirectly depending on it seems unreasonable for the "benefits" we get.
