### PR TITLE
Add [dq, dp, qi] attributes to jwk for compatibility with other libs

### DIFF
--- a/lib/json/jwk.rb
+++ b/lib/json/jwk.rb
@@ -90,7 +90,7 @@ module JSON
     end
 
     def to_rsa_key
-      e, n, d, p, q = [:e, :n, :d, :p, :q].collect do |key|
+      e, n, d, p, q, dp, dq, qi = [:e, :n, :d, :p, :q, :dp, :dq, :qi].collect do |key|
         if self[key]
           OpenSSL::BN.new UrlSafeBase64.decode64(self[key]), 2
         end
@@ -101,6 +101,9 @@ module JSON
       key.d = d if d
       key.p = p if p
       key.q = q if q
+      key.dmp1 = dp if dp
+      key.dmq1 = dq if dq
+      key.iqmp = qi if qi
       key
     end
 

--- a/lib/json/jwk/jwkizable.rb
+++ b/lib/json/jwk/jwkizable.rb
@@ -12,7 +12,10 @@ module JSON
             params.merge!(
               d: UrlSafeBase64.encode64(d.to_s(2)),
               p: UrlSafeBase64.encode64(p.to_s(2)),
-              q: UrlSafeBase64.encode64(q.to_s(2))
+              q: UrlSafeBase64.encode64(q.to_s(2)),
+              dp: UrlSafeBase64.encode64(dmp1.to_s(2)),
+              dq: UrlSafeBase64.encode64(dmq1.to_s(2)),
+              qi: UrlSafeBase64.encode64(iqmp.to_s(2)),
             )
           end
           JWK.new params


### PR DESCRIPTION
Add [dq, dp, qi] attributes to jwk for compatibility with other libs that require them such as the .NET jwk libs