### PR TITLE
update `to_rsa_key` to follow new openssl pkey interface

### DIFF
--- a/lib/json/jwk.rb
+++ b/lib/json/jwk.rb
@@ -102,14 +102,9 @@ module JSON
         end
       end
       key = OpenSSL::PKey::RSA.new
-      key.e = e
-      key.n = n
-      key.d = d if d
-      key.p = p if p
-      key.q = q if q
-      key.dmp1 = dp if dp
-      key.dmq1 = dq if dq
-      key.iqmp = qi if qi
+      key.set_key(n, e, d)
+      key.set_factors(p, q) if p && q
+      key.set_crt_params(dp, dq, qi) if dp && dq && qi
       key
     end
 


### PR DESCRIPTION
Looks like the OpenSSL interface was updated in Ruby 2.4
https://ruby-doc.org/stdlib-2.4.1/libdoc/openssl/rdoc/OpenSSL/PKey/RSA.html

Update the `to_rsa_key` method to the new interface.