### PR TITLE
Use Active Support's secure_compare

### DIFF
--- a/json-jwt.gemspec
+++ b/json-jwt.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.add_runtime_dependency 'activesupport'
   gem.add_runtime_dependency 'bindata'
-  gem.add_runtime_dependency 'securecompare'
   gem.add_runtime_dependency 'aes_key_wrap'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov'

--- a/lib/json/jose.rb
+++ b/lib/json/jose.rb
@@ -1,4 +1,4 @@
-require 'securecompare'
+require 'active_support/security_utils'
 
 module JSON
   module JOSE
@@ -6,7 +6,6 @@ module JSON
 
     included do
       extend ClassMethods
-      include SecureCompare
       register_header_keys :alg, :jku, :jwk, :x5u, :x5t, :x5c, :kid, :typ, :cty, :crit
       alias_method :algorithm, :alg
 
@@ -53,6 +52,18 @@ module JSON
         end
       rescue JSON::ParserError, ArgumentError
         raise JWT::InvalidFormat.new("Invalid JSON Format")
+      end
+
+      def secure_compare(a, b)
+        if ActiveSupport::SecurityUtils.respond_to?(:fixed_length_secure_compare)
+          begin
+            ActiveSupport::SecurityUtils.fixed_length_secure_compare(a, b)
+          rescue ArgumentError
+            false
+          end
+        else
+          ActiveSupport::SecurityUtils.secure_compare(a, b)
+        end
       end
     end
   end

--- a/lib/json/jwe.rb
+++ b/lib/json/jwe.rb
@@ -240,7 +240,7 @@ module JSON
       expected_authentication_tag = OpenSSL::HMAC.digest(
         sha_digest, mac_key, secured_input
       )[0, sha_size / 2 / 8]
-      unless secure_compare(authentication_tag, expected_authentication_tag)
+      unless self.class.secure_compare(authentication_tag, expected_authentication_tag)
         raise DecryptionFailed.new('Invalid authentication tag')
       end
     end

--- a/lib/json/jws.rb
+++ b/lib/json/jws.rb
@@ -128,7 +128,7 @@ module JSON
       public_key_or_secret = with_jwk_support public_key_or_secret
       case
       when hmac?
-        secure_compare sign(signature_base_string, public_key_or_secret), signature
+        self.class.secure_compare sign(signature_base_string, public_key_or_secret), signature
       when rsa?
         public_key = public_key_or_secret
         public_key.verify digest, signature, signature_base_string


### PR DESCRIPTION
The securecompare gem is literally the Active Support (which is already a dependency) method packaged in a gem.

Since https://github.com/rails/rails/commit/fa487763d98ccf9c3e66fdb44f09af5c37a50fe5 the implementation changed so we need to call the right method and rescue.

Without the rescue, this fails:
```
  1) JSON::JWT.decode when signed when secret/key given should do verification
     Failure/Error:
       expect do
         JSON::JWT.decode jws.to_s, 'secret'
       end.to raise_error JSON::JWT::VerificationFailed

       expected JSON::JWT::VerificationFailed, got #<JSON::JWT::InvalidFormat: Invalid JSON Format> with backtrace:
         # ./lib/json/jose.rb:52:in `rescue in decode'
         # ./lib/json/jose.rb:45:in `decode'
         # ./spec/json/jwt_spec.rb:193:in `block (6 levels) in <top (required)>'
         # ./spec/json/jwt_spec.rb:192:in `block (5 levels) in <top (required)>'
     # ./spec/json/jwt_spec.rb:192:in `block (5 levels) in <top (required)>'
```