### PR TITLE
Add support for a zero-octet payload in JWS.

### DIFF
--- a/lib/json/jws.rb
+++ b/lib/json/jws.rb
@@ -35,6 +35,7 @@ module JSON
       if hash_or_jwt.is_a? JSON::JWT
         self.header.update hash_or_jwt.header
         self.signature = hash_or_jwt.signature
+        self.blank_payload = hash_or_jwt.blank_payload
       end
       self
     end
@@ -181,8 +182,11 @@ module JSON
         header, claims, signature = input.split('.', JWS::NUM_OF_SEGMENTS).collect do |segment|
           Base64.urlsafe_decode64 segment.to_s
         end
-        header, claims = [header, claims].collect do |json|
-          JSON.parse(json).with_indifferent_access
+        header = JSON.parse(header).with_indifferent_access
+        if claims == ''
+          claims = nil
+        else
+          claims = JSON.parse(claims).with_indifferent_access
         end
         jws = new claims
         jws.header = header

--- a/spec/json/jws_spec.rb
+++ b/spec/json/jws_spec.rb
@@ -7,9 +7,17 @@ describe JSON::JWS do
     _jwt_.alg = alg
     _jwt_
   end
+  let(:jwt_blank) do
+    _jwt_ = JSON::JWT.new nil
+    _jwt_.alg = alg
+    _jwt_
+  end
   let(:jws) { JSON::JWS.new jwt }
+  let(:jws_blank) { JSON::JWS.new jwt_blank }
   let(:signed) { jws.sign! private_key_or_secret }
+  let(:signed_blank) { jws_blank.sign! private_key_or_secret }
   let(:decoded) { JSON::JWT.decode signed.to_s, public_key_or_secret }
+  let(:decoded_blank) { JSON::JWT.decode signed_blank.to_s, public_key_or_secret }
   let(:claims) do
     {
       iss: 'joe',
@@ -25,6 +33,16 @@ describe JSON::JWS do
       :RS256 => 'E5VELqAdla2Bx1axc9KFxO0EiCr0Mw6HPYX070qGQ8zA_XmyxGPUZLyyWU_6Cn399W-oYBWO2ynLlr8pqqjP3jXevyCeYeGRVN0HzLYiBebEugNnc3hevr7WV2UzfksWRA-Ux2bDv2sz9p_LGbL33wWNxGDvIlpDyZUul_a48nCipS0riBjkTLTSE8dfBxQTXEF5GEUUu99ot6aBLzUhc25nHXSXogXF6MHK-hAcE7f4v-vJ0lbPbHLVGUopIoxoqe4XjoBpzE5UvhrVl5LYbdjbyJhu5ZIA8GLsgwtUFh3dfdIechORoR3k5NSFSv8157bAEa8t4iwgWD2MSNSQnw',
       :RS384 => 'lT5JbytGKgG9QrwkJuxgw7UjmN9tjkEQW9pVGR2XnKEdC0_wLNIzAmT-jTwyMDGBLUkWO7opDOP6Xy6_DOTg58k9PwVkyQzrLnmxJMEng2Q-aMqcitRSIvUk3DPy8kemp8yUPls9NzWmByM2GoUVHbDsR0r-tZN-g_9QYev32mvMhjMr30JI5S2xiRjc9m2GAaXMOQmNTovJgV4bgCp4UjruCrA0BD1JJwDqKYoR_YYr_ALcVjD_LUgy80udJvbi8MAYJVUf0QYtQDrX2wnT_-eiiWjD5XafLuXEQVDRh-v2MKAwdvtXMq5cZ08Zjl2SyHxJ3OqhEeWPvYGltxZh_A',
       :RS512 => 'EHeGM2Mo3ghhUfSB99AlREehrbC6OPE-nYL_rwf88ysTnJ8L1QQ0UuCrXq4SpRutGLK_bYTK3ZALvFRPoOgK_g0QWmqv6qjQRU_QTxoq8y8APP-IgKKDuIiGH6daBV2rAPLDReqYNKsKjmTvZJo2c0a0e_WZkkj_ZwpgjTG3v0gW9lbDAzLJDz18eqtR4ZO7JTu_fyNrUrNk-w2_wpxSsn9sygIMp0lKE0_pt0b01fz3gjTDjlltU0cKSalUp4geaBDH7QRcexrolIctdQFbNKTXQxoigxD3NLNkKGH7f6A8KZdcOm8AnEjullcZs8_OWGnW43p1qrxoBRSivb9pqQ'
+    }
+  end
+  let(:expected_signature_blank_payload) do
+    {
+      :HS256 => 'iRFMM3GknVfzRTxlVQT87jfIw32Ik3lUYNGePPk5wnM',
+      :HS384 => 'rxyzr3I2RWRBgQaewQt3yjdp3BqkrFh-iHcet318OYHWhXvyzAE0npf0l0xi5DOV',
+      :HS512 => 'VDHOrPYrwycjaKbwccObXi6dmw4fVFqiFsNFQjqYHQAkxJGxqhfVLc1_WfKMa6C7vGSGroabaVdK7nn08XPdSQ',
+      :RS256 => 'WthQjouPVbErM7McwSY4slJjHaWqmFg1qKdmTDvttkiyAEcTjVViJkNHH9Mp573h13cXtLob1xh3UJYh5_-hSA4Y24zdyck3jp3fsOusflp1cMmhWXZ2nETKeWCEJDKRAnWynHqkwes7tgWmS0gVeuljeNkuovJlHmNRcoMR9Z3ZuiHfc2WFh-iFbM5Zne1y-_SSgAZwOD20P0Ysn28DtJTlXcm74ENqhLEJnvHS-872d6surb23kHMns43GtT5bm-aJoMLct0nO1GBapQAiKUknTsw24IfOkX4vJNQzIWVSzx3zOxXjcVHlH92af6NknIlPCfRparLC9YEK2NkJYg',
+      :RS384 => 'Jy6XNLNAyujRHYoCOtFqu7z0imHZMiwkwBr73ok_DDSDxQSA9ryt_q_tX0u8knpAIRcTJuNA0-s5DkGbpIj9coKgZ5JBvE_n9ijvNubImf8_vCDDitJemzUtnJypb9GbP4A3nWDAZC0KONVqlxpy92-9xrG5sFEzaYCFYZYnXv8kmmQEIVI1GXw4_Fx8HxRu5cae9WWTgaKQOFG54S303C0H966C1o6d9o3HQH7x8GEl632qBw4LzONWr_QpCN-UFgmJHO7yBwaP-RWnLDW3hYlb4IybRIvMQQicjkjNaNwLTmwo31orVxO53GcSjyhU2y_R843nQcNjTT_lD1QRvg',
+      :RS512 => 'ws2HZ6wvh8GMrFKiIHXDogyx8HFpa4wvrLxfZaMfCoMPf0SZ4V3tiEZRWfrxyvwpsdBj2Mgm5lt3IYAHhlI2hqWvuikDq6tuViloaAIm2xwTU060bF0GL1tQJ-h20wUukJ6fsWet8M9DNg7hcElYQMawHhk4L91YUtY2hKT_uWgPih_pn0Hq5Ve0at4CwAyXXTwCYSEH23PMsUdDfE5tfCyvL2bNQ71Ld_MvQS1NLS7hydzEtfxLK-UkDQVclFmEM3JXrPG7YSRodtKlwJ-ESDx6CaJXXDAgitSF32dslcIkmOXRJqjNmF15i_aVg0ExiU92WTpCrdwzWTt4Aphqlw',
     }
   end
 
@@ -49,6 +67,11 @@ describe JSON::JWS do
     shared_examples_for :generate_expected_signature do
       it do
         Base64.urlsafe_encode64(signed.signature, padding: false).should == expected_signature[alg]
+      end
+      context 'with blank payload' do
+        it do
+          Base64.urlsafe_encode64(signed_blank.signature, padding: false).should == expected_signature_blank_payload[alg]
+        end
       end
     end
     subject { signed }
@@ -176,6 +199,32 @@ describe JSON::JWS do
           decoded[:'http://example.com/is_root'] == true
         end
       end
+
+      context 'with blank payload' do
+        it do
+          expect { decoded_blank }.not_to raise_error
+          decoded_blank.should be_a JSON::JWT
+        end
+
+        describe 'header' do
+          let(:header) { decoded_blank.header }
+          it 'should be parsed successfully' do
+            header[:typ].should == 'JWT'
+            header[:alg].should == alg.to_s
+          end
+        end
+
+        describe 'claims' do
+          it 'should be parsed successfully' do
+            p decoded_blank.blank_payload
+            decoded_blank.blank_payload.should == true
+            decoded_blank[:iss].should == nil
+            decoded_blank[:exp].should == nil
+            decoded[:'http://example.com/is_root'] == nil
+          end
+        end
+      end
+
     end
     subject { decoded }
 
@@ -274,6 +323,12 @@ describe JSON::JWS do
         jws.to_json.should == claims.to_json
       end
     end
+    context 'with blank payload' do
+      it 'should JSONize payload' do
+        puts ("jws_blank: #{jws_blank.to_json.inspect}")
+        jws_blank.to_json.should == ''
+      end
+    end
 
     context 'when syntax option given' do
       context 'when general' do
@@ -286,6 +341,17 @@ describe JSON::JWS do
             }]
           }.to_json
         end
+        context 'with blank payload' do
+          it 'should return General JWS JSON Serialization' do
+            signed_blank.to_json(syntax: :general).should == {
+              payload: '',
+              signatures: [{
+                protected: Base64.urlsafe_encode64(signed_blank.header.to_json, padding: false),
+                signature: Base64.urlsafe_encode64(signed_blank.signature, padding: false)
+              }]
+            }.to_json
+          end
+        end
 
         context 'when not signed yet' do
           it 'should not fail' do
@@ -296,6 +362,17 @@ describe JSON::JWS do
                 signature: Base64.urlsafe_encode64('', padding: false)
               }]
             }.to_json
+          end
+          context 'with blank payload' do
+            it 'should not fail' do
+              jws_blank.to_json(syntax: :general).should == {
+                payload: '',
+                signatures: [{
+                  protected: Base64.urlsafe_encode64(jws_blank.header.to_json, padding: false),
+                  signature: Base64.urlsafe_encode64('', padding: false)
+                }]
+              }.to_json
+            end
           end
         end
       end
@@ -308,6 +385,15 @@ describe JSON::JWS do
             signature: Base64.urlsafe_encode64(signed.signature, padding: false)
           }.to_json
         end
+        context 'with blank payload' do
+          it 'should return Flattened JWS JSON Serialization' do
+            signed_blank.to_json(syntax: :flattened).should == {
+              protected: Base64.urlsafe_encode64(signed_blank.header.to_json, padding: false),
+              payload: '',
+              signature: Base64.urlsafe_encode64(signed_blank.signature, padding: false)
+            }.to_json
+          end
+        end
 
         context 'when not signed yet' do
           it 'should not fail' do
@@ -316,6 +402,15 @@ describe JSON::JWS do
               payload: Base64.urlsafe_encode64(claims.to_json, padding: false),
               signature: Base64.urlsafe_encode64('', padding: false)
             }.to_json
+          end
+          context 'with blank payload' do
+            it 'should not fail' do
+              jws_blank.to_json(syntax: :flattened).should == {
+                protected: Base64.urlsafe_encode64(jws_blank.header.to_json, padding: false),
+                payload: '',
+                signature: Base64.urlsafe_encode64('', padding: false)
+              }.to_json
+            end
           end
         end
       end


### PR DESCRIPTION
To create a JWT with a zero-octet payload, call JSON::JWT.new(nil)  A 
JWT created this way will have jwt.blank_payload set to true


This is required to support the POST-as-GET functionality in the ACME 
spec.

This will resolve https://github.com/nov/json-jwt/issues/69