### PR TITLE
Ruby Warnings

### DIFF
--- a/lib/json/jose.rb
+++ b/lib/json/jose.rb
@@ -9,7 +9,7 @@ module JSON
       register_header_keys :alg, :jku, :jwk, :x5u, :x5t, :x5c, :kid, :typ, :cty, :crit
       alias_method :algorithm, :alg
 
-      attr_accessor :header
+      attr_writer :header
       def header
         @header ||= {}
       end

--- a/lib/json/jwe.rb
+++ b/lib/json/jwe.rb
@@ -14,9 +14,10 @@ module JSON
 
     attr_accessor(
       :public_key_or_secret, :private_key_or_secret,
-      :plain_text, :cipher_text, :authentication_tag, :iv, :auth_data,
-      :content_encryption_key, :jwe_encrypted_key, :encryption_key, :mac_key
+      :plain_text, :cipher_text, :iv, :auth_data,
+      :content_encryption_key, :encryption_key, :mac_key
     )
+    attr_writer :jwe_encrypted_key, :authentication_tag
 
     register_header_keys :enc, :epk, :zip, :apu, :apv
     alias_method :encryption_method, :enc

--- a/lib/json/jws.rb
+++ b/lib/json/jws.rb
@@ -6,7 +6,7 @@ module JSON
 
     NUM_OF_SEGMENTS = 3
 
-    attr_accessor :signature_base_string
+    attr_writer :signature_base_string
 
     def initialize(jwt)
       update jwt


### PR DESCRIPTION
This patch eliminates Ruby warnings when RUBYOPT=-w.

To reproduce:
`%ruby -wrjson/jwt -ep`