### PR TITLE
Remove Active Support

### DIFF
--- a/json-jwt.gemspec
+++ b/json-jwt.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
   gem.required_ruby_version = '>= 2.3'
-  gem.add_runtime_dependency 'activesupport', '>= 4.2'
   gem.add_runtime_dependency 'bindata'
   gem.add_runtime_dependency 'aes_key_wrap'
   gem.add_runtime_dependency 'securecompare'

--- a/json-jwt.gemspec
+++ b/json-jwt.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'activesupport', '>= 4.2'
   gem.add_runtime_dependency 'bindata'
   gem.add_runtime_dependency 'aes_key_wrap'
+  gem.add_runtime_dependency 'securecompare'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rspec'

--- a/lib/json/jose.rb
+++ b/lib/json/jose.rb
@@ -1,4 +1,4 @@
-require 'active_support/security_utils'
+require 'securecompare'
 
 module JSON
   module JOSE
@@ -6,6 +6,7 @@ module JSON
 
     included do
       extend ClassMethods
+      include SecureCompare
       register_header_keys :alg, :jku, :jwk, :x5u, :x5t, :x5c, :kid, :typ, :cty, :crit
       alias_method :algorithm, :alg
 
@@ -29,18 +30,6 @@ module JSON
         end&.to_key or raise JWK::Set::KidNotFound
       else
         key
-      end
-    end
-
-    def secure_compare(a, b)
-      if ActiveSupport::SecurityUtils.respond_to?(:fixed_length_secure_compare)
-        begin
-          ActiveSupport::SecurityUtils.fixed_length_secure_compare(a, b)
-        rescue ArgumentError
-          false
-        end
-      else
-        ActiveSupport::SecurityUtils.secure_compare(a, b)
       end
     end
 

--- a/lib/json/jose.rb
+++ b/lib/json/jose.rb
@@ -2,21 +2,22 @@ require 'securecompare'
 
 module JSON
   module JOSE
-    extend ActiveSupport::Concern
+    def self.included(base)
+      base.extend ClassMethods
+      base.class_eval do
+        extend ClassMethods
+        include SecureCompare
+        register_header_keys :alg, :jku, :jwk, :x5u, :x5t, :x5c, :kid, :typ, :cty, :crit
+        alias_method :algorithm, :alg
 
-    included do
-      extend ClassMethods
-      include SecureCompare
-      register_header_keys :alg, :jku, :jwk, :x5u, :x5t, :x5c, :kid, :typ, :cty, :crit
-      alias_method :algorithm, :alg
+        attr_writer :header
+        def header
+          @header ||= {}
+        end
 
-      attr_writer :header
-      def header
-        @header ||= {}
-      end
-
-      def content_type
-        @content_type ||= 'application/jose'
+        def content_type
+          @content_type ||= 'application/jose'
+        end
       end
     end
 

--- a/lib/json/jwe.rb
+++ b/lib/json/jwe.rb
@@ -262,7 +262,7 @@ module JSON
           end
         end
         jwe.auth_data = input.split('.').first
-        jwe.header = JSON.parse(_header_json_).with_indifferent_access
+        jwe.header = JSON.parse(_header_json_, symbolize_names: true)
         unless private_key_or_secret == :skip_decryption
           jwe.decrypt! private_key_or_secret, algorithms, encryption_methods
         end
@@ -270,7 +270,6 @@ module JSON
       end
 
       def decode_json_serialized(input, private_key_or_secret, algorithms = nil, encryption_methods = nil, _allow_blank_payload = false)
-        input = input.with_indifferent_access
         jwe_encrypted_key = if input[:recipients].present?
           input[:recipients].first[:encrypted_key]
         else

--- a/lib/json/jwe.rb
+++ b/lib/json/jwe.rb
@@ -40,8 +40,8 @@ module JSON
     end
 
     def decrypt!(private_key_or_secret, algorithms = nil, encryption_methods = nil)
-      raise UnexpectedAlgorithm.new('Unexpected alg header') unless algorithms.blank? || Array(algorithms).include?(alg)
-      raise UnexpectedAlgorithm.new('Unexpected enc header') unless encryption_methods.blank? || Array(encryption_methods).include?(enc)
+      raise UnexpectedAlgorithm.new('Unexpected alg header') unless algorithms.nil? || Array(algorithms).include?(alg)
+      raise UnexpectedAlgorithm.new('Unexpected enc header') unless encryption_methods.nil? || Array(encryption_methods).include?(enc)
       self.private_key_or_secret = with_jwk_support private_key_or_secret
       cipher.decrypt
       self.content_encryption_key = decrypt_content_encryption_key
@@ -270,7 +270,7 @@ module JSON
       end
 
       def decode_json_serialized(input, private_key_or_secret, algorithms = nil, encryption_methods = nil, _allow_blank_payload = false)
-        jwe_encrypted_key = if input[:recipients].present?
+        jwe_encrypted_key = if input[:recipients]
           input[:recipients].first[:encrypted_key]
         else
           input[:encrypted_key]

--- a/lib/json/jwk.rb
+++ b/lib/json/jwk.rb
@@ -13,7 +13,7 @@ module JSON
       else
         super().merge!(params).merge!(ex_params)
       end
-      calculate_default_kid if self[:kid].blank?
+      calculate_default_kid if self[:kid].nil?
     end
 
     def content_type

--- a/lib/json/jwk/jwkizable.rb
+++ b/lib/json/jwk/jwkizable.rb
@@ -2,7 +2,7 @@ module JSON
   class JWK
     module JWKizable
       module RSA
-        def to_jwk(ex_params = {})
+        def to_jwk_params(ex_params = {})
           params = {
             kty: :RSA,
             e: Base64.urlsafe_encode64(e.to_s(2), padding: false),
@@ -18,12 +18,16 @@ module JSON
               qi: Base64.urlsafe_encode64(iqmp.to_s(2), padding: false),
             )
           end
-          JWK.new params
+          params
+        end
+
+        def to_jwk(ex_params = {})
+          JWK.new to_jwk_params(ex_params)
         end
       end
 
       module EC
-        def to_jwk(ex_params = {})
+        def to_jwk_params(ex_params = {})
           params = {
             kty: :EC,
             crv: curve_name,
@@ -31,7 +35,11 @@ module JSON
             y: Base64.urlsafe_encode64([coordinates[:y]].pack('H*'), padding: false)
           }.merge ex_params
           params[:d] = Base64.urlsafe_encode64([coordinates[:d]].pack('H*'), padding: false) if private_key?
-          JWK.new params
+          params
+        end
+
+        def to_jwk(ex_params = {})
+          JWK.new to_jwk_params(ex_params)
         end
 
         private

--- a/lib/json/jwk/set.rb
+++ b/lib/json/jwk/set.rb
@@ -5,7 +5,7 @@ module JSON
 
       def initialize(*jwks)
         jwks = if jwks.first.is_a?(Hash) && (keys = jwks.first[:keys])
-          keys
+          [keys]
         else
           jwks
         end

--- a/lib/json/jwk/set.rb
+++ b/lib/json/jwk/set.rb
@@ -4,7 +4,7 @@ module JSON
       class KidNotFound < JWT::Exception; end
 
       def initialize(*jwks)
-        jwks = if jwks.first.is_a?(Hash) && (keys = jwks.first.with_indifferent_access[:keys])
+        jwks = if jwks.first.is_a?(Hash) && (keys = jwks.first[:keys])
           keys
         else
           jwks

--- a/lib/json/jws.rb
+++ b/lib/json/jws.rb
@@ -182,11 +182,11 @@ module JSON
         header, claims, signature = input.split('.', JWS::NUM_OF_SEGMENTS).collect do |segment|
           Base64.urlsafe_decode64 segment.to_s
         end
-        header = JSON.parse(header).with_indifferent_access
+        header = JSON.parse(header, symbolize_names: true)
         if allow_blank_payload && claims == ''
           claims = nil
         else
-          claims = JSON.parse(claims).with_indifferent_access
+          claims = JSON.parse(claims, symbolize_names: true)
         end
         jws = new claims
         jws.header = header
@@ -197,7 +197,6 @@ module JSON
       end
 
       def decode_json_serialized(input, public_key_or_secret, algorithms = nil, allow_blank_payload = false)
-        input = input.with_indifferent_access
         header, payload, signature = if input[:signatures].present?
           [
             input[:signatures].first[:protected],

--- a/lib/json/jws.rb
+++ b/lib/json/jws.rb
@@ -22,7 +22,7 @@ module JSON
       if alg&.to_sym == :none
         raise UnexpectedAlgorithm if public_key_or_secret
         signature == '' or raise VerificationFailed
-      elsif algorithms.blank? || Array(algorithms).include?(alg&.to_sym)
+      elsif algorithms.nil? || Array(algorithms).include?(alg&.to_sym)
         public_key_or_secret && valid?(public_key_or_secret) or
         raise VerificationFailed
       else
@@ -197,7 +197,7 @@ module JSON
       end
 
       def decode_json_serialized(input, public_key_or_secret, algorithms = nil, allow_blank_payload = false)
-        header, payload, signature = if input[:signatures].present?
+        header, payload, signature = if input[:signatures]
           [
             input[:signatures].first[:protected],
             input[:payload],

--- a/lib/json/jwt.rb
+++ b/lib/json/jwt.rb
@@ -110,9 +110,9 @@ module JSON
       end
 
       def decode_json_serialized(input, key_or_secret, algorithms = nil, encryption_methods = nil, allow_blank_payload = false)
-        if (input[:signatures] || input[:signature]).present?
+        if (input[:signatures] || input[:signature])
           JWS.decode_json_serialized input, key_or_secret, algorithms, allow_blank_payload
-        elsif input[:ciphertext].present?
+        elsif input[:ciphertext]
           JWE.decode_json_serialized input, key_or_secret, algorithms, encryption_methods
         else
           raise InvalidFormat.new("Unexpected JOSE JSON Serialization Format.")

--- a/lib/json/jwt.rb
+++ b/lib/json/jwt.rb
@@ -5,7 +5,7 @@ require 'active_support/core_ext'
 require 'json/jose'
 
 module JSON
-  class JWT < ActiveSupport::HashWithIndifferentAccess
+  class JWT < Hash
     attr_accessor :blank_payload
     attr_accessor :signature
 
@@ -110,7 +110,6 @@ module JSON
       end
 
       def decode_json_serialized(input, key_or_secret, algorithms = nil, encryption_methods = nil, allow_blank_payload = false)
-        input = input.with_indifferent_access
         if (input[:signatures] || input[:signature]).present?
           JWS.decode_json_serialized input, key_or_secret, algorithms, allow_blank_payload
         elsif input[:ciphertext].present?

--- a/lib/json/jwt.rb
+++ b/lib/json/jwt.rb
@@ -1,7 +1,5 @@
 require 'openssl'
 require 'base64'
-require 'active_support'
-require 'active_support/core_ext'
 require 'json/jose'
 
 module JSON

--- a/spec/json/jwk/jwkizable_spec.rb
+++ b/spec/json/jwk/jwkizable_spec.rb
@@ -6,14 +6,14 @@ describe JSON::JWK::JWKizable do
 
     shared_examples_for :jwkizable_as_public do
       it { should be_instance_of JSON::JWK }
-      it { should include *public_key_attributes.collect(&:to_s) }
-      it { should_not include *private_key_attributes.collect(&:to_s) }
+      it { should include *public_key_attributes }
+      it { should_not include *private_key_attributes }
     end
 
     shared_examples_for :jwkizable_as_private do
       it { should be_instance_of JSON::JWK }
-      it { should include *public_key_attributes.collect(&:to_s) }
-      it { should include *private_key_attributes.collect(&:to_s) }
+      it { should include *public_key_attributes }
+      it { should include *private_key_attributes }
     end
 
     describe OpenSSL::PKey::RSA do

--- a/spec/json/jwk/set_spec.rb
+++ b/spec/json/jwk/set_spec.rb
@@ -36,7 +36,7 @@ describe JSON::JWK::Set do
   end
 
   context 'when pure Hash given' do
-    subject { JSON::JWK::Set.new jwk.as_json }
+    subject { JSON::JWK::Set.new jwk }
 
     it 'should convert into JSON::JWK' do
       subject.each do |jwk|
@@ -48,7 +48,7 @@ describe JSON::JWK::Set do
   context 'when pure Hash with :keys key given' do
     subject do
       JSON::JWK::Set.new(
-        keys: jwk.as_json
+        keys: jwk
       )
     end
 

--- a/spec/json/jwk_spec.rb
+++ b/spec/json/jwk_spec.rb
@@ -77,14 +77,14 @@ describe JSON::JWK do
 
   context 'when RSA public key given' do
     let(:jwk) { JSON::JWK.new public_key }
-    it { jwk.keys.collect(&:to_sym).should include :kty, :e, :n }
+    it { jwk.keys.should include :kty, :e, :n }
     its(:kty) { jwk[:kty].should == :RSA }
     its(:e) { jwk[:e].should == Base64.urlsafe_encode64(public_key.e.to_s(2), padding: false) }
     its(:n) { jwk[:n].should == Base64.urlsafe_encode64(public_key.n.to_s(2), padding: false) }
 
     context 'when kid/use options given' do
       let(:jwk) { JSON::JWK.new public_key, kid: '12345', use: :sig }
-      it { jwk.keys.collect(&:to_sym).should include :kid, :use }
+      it { jwk.keys.should include :kid, :use }
       its(:kid) { jwk[:kid].should == '12345' }
       its(:use) { jwk[:use].should == :sig }
     end
@@ -128,7 +128,7 @@ describe JSON::JWK do
     [256, 384, 512].each do |digest_length|
       describe "EC#{digest_length}" do
         let(:jwk) { JSON::JWK.new public_key(:ecdsa, digest_length: digest_length) }
-        it { jwk.keys.collect(&:to_sym).should include :kty, :crv, :x, :y }
+        it { jwk.keys.should include :kty, :crv, :x, :y }
         its(:kty) { jwk[:kty].should == :EC }
         its(:x) { jwk[:x].should == expected_coordinates[digest_length][:x] }
         its(:y) { jwk[:y].should == expected_coordinates[digest_length][:y] }

--- a/spec/json/jwk_spec.rb
+++ b/spec/json/jwk_spec.rb
@@ -17,13 +17,13 @@ describe JSON::JWK do
       it { should be_instance_of JSON::JWK }
       describe 'kid' do
         subject { jwk[:kid] }
-        it { should be_blank }
+        it { should be_nil }
       end
     end
 
     context 'when no imput' do
       it do
-        JSON::JWK.new.should be_blank
+        JSON::JWK.new.should be_empty
       end
     end
 

--- a/spec/json/jws_spec.rb
+++ b/spec/json/jws_spec.rb
@@ -22,7 +22,7 @@ describe JSON::JWS do
     {
       iss: 'joe',
       exp: 1300819380,
-      :'http://example.com/is_root' => true
+      'http://example.com/is_root': true
     }
   end
   let(:expected_signature) do

--- a/spec/json/jws_spec.rb
+++ b/spec/json/jws_spec.rb
@@ -354,45 +354,45 @@ describe JSON::JWS do
     context 'when syntax option given' do
       context 'when general' do
         it 'should return General JWS JSON Serialization' do
-          signed.to_json(syntax: :general).should == {
+          signed.as_json(syntax: :general).should == {
             payload: Base64.urlsafe_encode64(claims.to_json, padding: false),
             signatures: [{
               protected: Base64.urlsafe_encode64(signed.header.to_json, padding: false),
               signature: Base64.urlsafe_encode64(signed.signature, padding: false)
             }]
-          }.to_json
+          }
         end
         context 'with blank payload' do
           it 'should return General JWS JSON Serialization' do
-            signed_blank.to_json(syntax: :general).should == {
+            signed_blank.as_json(syntax: :general).should == {
               payload: '',
               signatures: [{
                 protected: Base64.urlsafe_encode64(signed_blank.header.to_json, padding: false),
                 signature: Base64.urlsafe_encode64(signed_blank.signature, padding: false)
               }]
-            }.to_json
+            }
           end
         end
 
         context 'when not signed yet' do
           it 'should not fail' do
-            jws.to_json(syntax: :general).should == {
+            jws.as_json(syntax: :general).should == {
               payload: Base64.urlsafe_encode64(claims.to_json, padding: false),
               signatures: [{
                 protected: Base64.urlsafe_encode64(jws.header.to_json, padding: false),
                 signature: Base64.urlsafe_encode64('', padding: false)
               }]
-            }.to_json
+            }
           end
           context 'with blank payload' do
             it 'should not fail' do
-              jws_blank.to_json(syntax: :general).should == {
+              jws_blank.as_json(syntax: :general).should == {
                 payload: '',
                 signatures: [{
                   protected: Base64.urlsafe_encode64(jws_blank.header.to_json, padding: false),
                   signature: Base64.urlsafe_encode64('', padding: false)
                 }]
-              }.to_json
+              }
             end
           end
         end
@@ -400,37 +400,37 @@ describe JSON::JWS do
 
       context 'when flattened' do
         it 'should return Flattened JWS JSON Serialization' do
-          signed.to_json(syntax: :flattened).should == {
+          signed.as_json(syntax: :flattened).should == {
             protected: Base64.urlsafe_encode64(signed.header.to_json, padding: false),
             payload: Base64.urlsafe_encode64(claims.to_json, padding: false),
             signature: Base64.urlsafe_encode64(signed.signature, padding: false)
-          }.to_json
+          }
         end
         context 'with blank payload' do
           it 'should return Flattened JWS JSON Serialization' do
-            signed_blank.to_json(syntax: :flattened).should == {
+            signed_blank.as_json(syntax: :flattened).should == {
               protected: Base64.urlsafe_encode64(signed_blank.header.to_json, padding: false),
               payload: '',
               signature: Base64.urlsafe_encode64(signed_blank.signature, padding: false)
-            }.to_json
+            }
           end
         end
 
         context 'when not signed yet' do
           it 'should not fail' do
-            jws.to_json(syntax: :flattened).should == {
+            jws.as_json(syntax: :flattened).should == {
               protected: Base64.urlsafe_encode64(jws.header.to_json, padding: false),
               payload: Base64.urlsafe_encode64(claims.to_json, padding: false),
               signature: Base64.urlsafe_encode64('', padding: false)
-            }.to_json
+            }
           end
           context 'with blank payload' do
             it 'should not fail' do
-              jws_blank.to_json(syntax: :flattened).should == {
+              jws_blank.as_json(syntax: :flattened).should == {
                 protected: Base64.urlsafe_encode64(jws_blank.header.to_json, padding: false),
                 payload: '',
                 signature: Base64.urlsafe_encode64('', padding: false)
-              }.to_json
+              }
             end
           end
         end

--- a/spec/json/jwt_spec.rb
+++ b/spec/json/jwt_spec.rb
@@ -12,8 +12,8 @@ describe JSON::JWT do
     {
       iss: 'joe',
       exp: 1300819380,
-      'http://example.com/is_root' => true
-    }.with_indifferent_access
+      'http://example.com/is_root': true
+    }
   end
   let(:no_signed) do
     'eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJpc3MiOiJqb2UiLCJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.'
@@ -375,7 +375,7 @@ describe JSON::JWT do
         it 'should skip verification' do
           expect do
             jwt = JSON::JWT.decode jws.to_s, :skip_verification
-            jwt.header.should == {'alg' => 'HS256', 'typ' => 'JWT'}
+            jwt.header.should == {alg: 'HS256', typ: 'JWT'}
           end.not_to raise_error
         end
       end
@@ -440,7 +440,7 @@ describe JSON::JWT do
           expect do
             jwe = JSON::JWT.decode input, :skip_decryption
             jwe.should be_instance_of JSON::JWE
-            jwe.header.should == {'alg' => 'RSA1_5', 'enc' => 'A128CBC-HS256'}
+            jwe.header.should == {alg: 'RSA1_5', enc: 'A128CBC-HS256'}
           end.not_to raise_error
         end
       end

--- a/spec/json/jwt_spec.rb
+++ b/spec/json/jwt_spec.rb
@@ -110,7 +110,7 @@ describe JSON::JWT do
       let(:key) { private_key }
       it 'should not set kid header automatically' do
         jws = jwt.sign(key, :RS256)
-        jws.kid.should be_blank
+        jws.kid.should be_nil
       end
     end
 
@@ -118,7 +118,7 @@ describe JSON::JWT do
       let(:key) { JSON::JWK.new private_key }
       it 'should set kid header automatically' do
         jws = jwt.sign(key, :RS256)
-        jwt.kid.should be_blank
+        jwt.kid.should be_nil
         jws.kid.should == key[:kid]
       end
     end
@@ -182,7 +182,7 @@ describe JSON::JWT do
       let(:key) { shared_key }
       it 'should not set kid header automatically' do
         jwe = jwt.encrypt(key, :dir)
-        jwe.kid.should be_blank
+        jwe.kid.should be_nil
       end
     end
 
@@ -190,7 +190,7 @@ describe JSON::JWT do
       let(:key) { JSON::JWK.new shared_key }
       it 'should set kid header automatically' do
         jwe = jwt.encrypt(key, :dir)
-        jwt.kid.should be_blank
+        jwt.kid.should be_nil
         jwe.kid.should == key[:kid]
       end
     end


### PR DESCRIPTION
With some small changes usage of Active Support can be removed, which makes it easier for library authors to use this gem since they don't pull in AS' monkey patches.