### PR TITLE
Properly handle optional key ID parameter

### DIFF
--- a/lib/json/jose.rb
+++ b/lib/json/jose.rb
@@ -26,11 +26,23 @@ module JSON
       when JSON::JWK
         key.to_key
       when JSON::JWK::Set
-        key.detect do |jwk|
-          jwk[:kid] && jwk[:kid] == kid
-        end&.to_key or raise JWK::Set::KidNotFound
+        find_key(key)
       else
         key
+      end
+    end
+
+    def find_key(key)
+      if kid
+        found_key = key.detect { |jwk| jwk[:kid] && jwk[:kid] == kid }
+
+        return found_key.to_key if found_key
+
+        raise JWK::Set::KidNotFound
+      elsif key.length > 1
+        raise JWK::Set::KidNotFound
+      elsif key.length == 1
+        key[0].to_key
       end
     end
 

--- a/spec/json/jws_spec.rb
+++ b/spec/json/jws_spec.rb
@@ -186,6 +186,17 @@ describe JSON::JWS do
       end
     end
 
+    context 'when JSON::JWK::Set has only one key' do
+      let(:alg) { :HS256 }
+      let(:jwks) do
+        jwk = JSON::JWK.new shared_secret
+        JSON::JWK::Set.new jwk
+      end
+      let(:signed) { jws.sign!(jwks) }
+
+      it { should == jws.sign!('secret') }
+    end
+
     context 'when JSON::JWK::Set key given' do
       let(:alg) { :HS256 }
       let(:kid) { 'kid' }
@@ -198,6 +209,16 @@ describe JSON::JWS do
       context 'when jwk is found by given kid' do
         before { jws.kid = kid }
         it { should == jws.sign!('secret') }
+      end
+
+      context 'when kid is unknown' do
+        before { jws.kid = 'unknown_kid' }
+
+        it do
+          expect do
+            subject
+          end.to raise_error JSON::JWK::Set::KidNotFound
+        end
       end
 
       context 'otherwise' do


### PR DESCRIPTION
As defined in https://tools.ietf.org/html/rfc7515#section-4.1.4, the
`kid` (Key ID) parameter is optional and helps to disambiguate multiple
keys.

If there is only a single key and `kid` is not provided, then we can
just return the only key present.

Relates to https://github.com/m0n9oose/omniauth_openid_connect/issues/64

Originally reported in https://gitlab.com/gitlab-org/gitlab/-/issues/225850