### PR TITLE
Support openssl 3 (Fixes: #100)

### DIFF
--- a/lib/json/jws.rb
+++ b/lib/json/jws.rb
@@ -156,8 +156,8 @@ module JSON
       when 512
         :secp521r1
       end
-      key.group = OpenSSL::PKey::EC::Group.new group_name.to_s
-      key.check_key
+      newkey = OpenSSL::PKey::EC.generate(group_name.to_s)
+      newkey.check_key
     end
 
     def raw_to_asn1(signature, public_key)

--- a/spec/json/jwk_spec.rb
+++ b/spec/json/jwk_spec.rb
@@ -145,7 +145,7 @@ describe JSON::JWK do
 
     describe 'unknown curve' do
       it do
-        key = OpenSSL::PKey::EC.new('secp112r2').generate_key
+        key = OpenSSL::PKey::EC.generate('secp112r2')
         expect do
           JSON::JWK.new key
         end.to raise_error JSON::JWK::UnknownAlgorithm, 'Unknown EC Curve'
@@ -193,7 +193,7 @@ describe JSON::JWK do
 
   describe 'unknown key type' do
     it do
-      key = OpenSSL::PKey::DSA.generate 256
+      key = OpenSSL::PKey::DSA.generate 2048
       expect do
         JSON::JWK.new key
       end.to raise_error JSON::JWK::UnknownAlgorithm, 'Unknown Key Type'


### PR DESCRIPTION
The openssl API introduced some breaking changes which are fixed by this
commit. For more information about those changes check this out:

https://github.com/ruby/openssl/blob/master/History.md#version-300

Co-authored-by: Sergio Durigan Junior <sergiodj@ubuntu.com>

With the proposed changes all tests are passing with OpenSSL 3. You can easily test it in a system running Ubuntu 22.04 which has OpenSSL 3 as the default.