### PR TITLE
Add Github Action to test against OpenSSL 3

### DIFF
--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -1,0 +1,30 @@
+name: Test Ruby
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: ['ubuntu-18.04', 'ubuntu-20.04']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        # ubuntu 22.04 only supports ssl 3 and thus only ruby 3.1
+        include:
+        - os: 'ubuntu-22.04'
+          ruby-version: '3.1'
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Run tests
+      run: bundle exec rake


### PR DESCRIPTION
This pull request adds tests against OpenSSL 3.

It does this by adding a Github Action workflow to test against Ruby 2.5 till 3.1 on Ubuntu 18.04 and 20.04 and against Ruby 3.1 on Ubuntu 22.04.

Ubuntu 22.04 only supports OpenSSL 3 and thus only supports Ruby 3.1.

If this gets merged, the Travis workflow could be removed.