### PR TITLE
Comment out the security utils require and add manually in initialize…

### DIFF
--- a/lib/json/jose.rb
+++ b/lib/json/jose.rb
@@ -1,4 +1,4 @@
-require 'active_support/security_utils'
+#require 'active_support/security_utils'
 
 module JSON
   module JOSE


### PR DESCRIPTION
security_util is not available in Rails 4.1.5 so I commented it out and manually copied the code of security_util in initializers