### PR TITLE
Remove padding oracle

### DIFF
--- a/spec/json/jwe_spec.rb
+++ b/spec/json/jwe_spec.rb
@@ -123,8 +123,27 @@ describe JSON::JWE do
         it_behaves_like :signature_verification_failure
       end
 
-      describe "with corrupted signature" do
-        let(:signature) { Base64.urlsafe_encode64(Base64.urlsafe_decode64(super()).reverse) }
+      describe "with good pkcs7 padding and bad signature" do
+        let(:iv) do
+          good_padding_byte = 16 - (plain_text.bytesize % 16)
+          bad_padding_byte = 1
+          iv_bytes = Base64.urlsafe_decode64(super()).bytes
+          iv_bytes[-1] = iv_bytes[-1] ^ good_padding_byte ^ bad_padding_byte
+          Base64.urlsafe_encode64(iv_bytes.pack("C*"), padding: false)
+        end
+
+        it_behaves_like :signature_verification_failure
+      end
+
+      describe "with bad pkcs7 padding and bad signature" do
+        let(:iv) do
+          good_padding_byte = 16 - (plain_text.bytesize % 16)
+          bad_padding_byte = good_padding_byte - 1
+          iv_bytes = Base64.urlsafe_decode64(super()).bytes
+          iv_bytes[-1] = iv_bytes[-1] ^ good_padding_byte ^ bad_padding_byte
+          Base64.urlsafe_encode64(iv_bytes.pack("C*"), padding: false)
+        end
+
         it_behaves_like :signature_verification_failure
       end
     end


### PR DESCRIPTION
The library doesn't rescue from `OpenSSL::Cipher::CipherError` errors raised by OpenSSL when PKCS7 padding is invalid. The library also attempts to decrypt the ciphertext before verifying the signature. Other decryption failures result in sublcasses of `JSON::JWT::Exception` being raised, meaning that consumers of this library are quite likely only attempting to handle those errors.

The result is that a consuming application could quite easily fall into the trap of handling PKCS7 padding errors in a way that is observably different from how signature validation errors are handled. This would enable an exploitable padding-oracle attack against the consuming application. Cryptography libraries should attempt to be misuse-resistant and not leave it up to the consumer to worry about subtle crypto bugs.

This PR rescues from `OpenSSL::OpenSSLError` errors during decryption and raises an exception that is identical to those raised for invalid signatures. It also moves the signature checking to _before_ decryption is attempted.

This bug was disclosed to the author via email on 9/9/22. On 10/4/22 the author responded, saying that consuming applications should handle this.