### PR TITLE
fix secp256k1 curve name to follow the standards

### DIFF
--- a/lib/json/jwk/jwkizable.rb
+++ b/lib/json/jwk/jwkizable.rb
@@ -45,7 +45,7 @@ module JSON
           when 'secp521r1'
             :'P-521'
           when 'secp256k1'
-            :secp256k1
+            :'P-256K'
           else
             raise UnknownAlgorithm.new('Unknown EC Curve')
           end


### PR DESCRIPTION
Hi. I found that crv claim could be wrong when I use secp256k1. 
This PR fixes a crv claim to follow the standards so that I can use secp256k1 and parse resulting JWTs with other libraries.

the problem is that crv claim is `secp256k1`. It is an OpenSSL style curve name so it should be `P-256K` according to [this](https://datatracker.ietf.org/doc/html/draft-jones-webauthn-secp256k1#section-2). Also, [ruby-jwt](https://github.com/jwt/ruby-jwt/blob/771630d10cf0e6b1736ff8df03e4056b5de61676/lib/jwt/jwk/ec.rb#L216) assumes crv claim to be `P-256K`. Because of that, I can't decode JWT created using `json-jwt`.

