### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/json-jwt

### DIFF
--- a/json-jwt.gemspec
+++ b/json-jwt.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-its'
+  gem.metadata["changelog_uri"] = gem.homepage + "/releases"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/json-jwt which makes it quick and easy for someone to check on the changes introduced with a new version.

I chose to link to the '[/releases](https://github.com/nov/json-jwt/releases)' page since that has more details in it than the [CHANGELOG.md](https://github.com/nov/json-jwt/blob/main/CHANGELOG.md) in the source code repository.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/