### PR TITLE
Backport fix for CVE-2023-51774 from 1.16.6 to 1.15.x

### DIFF
--- a/lib/json/jwt.rb
+++ b/lib/json/jwt.rb
@@ -108,7 +108,11 @@ module JSON
         when JWS::NUM_OF_SEGMENTS
           JWS.decode_compact_serialized jwt_string, key_or_secret, algorithms, allow_blank_payload
         when JWE::NUM_OF_SEGMENTS
-          JWE.decode_compact_serialized jwt_string, key_or_secret, algorithms, encryption_methods
+          if allow_blank_payload
+            raise InvalidFormat.new("JWE w/ blank payload is not supported.")
+          else
+            JWE.decode_compact_serialized jwt_string, key_or_secret, algorithms, encryption_methods
+          end
         else
           raise InvalidFormat.new("Invalid JWT Format. JWT should include #{JWS::NUM_OF_SEGMENTS} or #{JWE::NUM_OF_SEGMENTS} segments.")
         end

--- a/spec/json/jwt_spec.rb
+++ b/spec/json/jwt_spec.rb
@@ -504,6 +504,14 @@ describe JSON::JWT do
         end
       end
     end
+
+    context 'when JWE format (5 segments) and allow_blank_payload is true' do
+      it do
+        expect do
+          JSON::JWT.decode 'one.two.three.four.five', 'secret', nil, nil, true
+        end.to raise_error JSON::JWT::InvalidFormat
+      end
+    end
   end
 
   describe '.pretty_generate' do


### PR DESCRIPTION
@nov this backports [your fix](https://github.com/nov/json-jwt/commit/9c4d842a9465bd7960570ca326c3de79b4abc9d0) to a branch created from [the last commit on 1.15.x](https://github.com/nov/json-jwt/commit/7ec09aa67aa85550232b165bf25ea65ccc0581a3).  I also added a test for the fix.

Refs https://github.com/nov/json-jwt/issues/121
