### PR TITLE
Don't try to modify the passed in hash

### DIFF
--- a/lib/json/jwt.rb
+++ b/lib/json/jwt.rb
@@ -26,12 +26,12 @@ module JSON
       @content_type = 'application/jwt'
       self.typ = :JWT
       self.alg = :none
+      update claims
       unless claims.nil?
         [:exp, :nbf, :iat].each do |key|
-          claims[key] = claims[key].to_i if claims[key]
+          self[key] = self[key].to_i if self[key]
         end
       end
-      update claims
     end
 
     def sign(private_key_or_secret, algorithm = :autodetect)

--- a/spec/json/jwt_spec.rb
+++ b/spec/json/jwt_spec.rb
@@ -23,6 +23,15 @@ describe JSON::JWT do
     JSON::JWT::VERSION.should_not be_blank
   end
 
+  describe '#initialize' do
+    it "doesn't try to modify a frozen hash" do
+      claims = { iss: 'joe', exp: '1300819380' }.freeze
+      jwt = JSON::JWT.new(claims)
+      expect(jwt[:exp]).to eql 1300819380
+      expect(claims[:exp]).to eql '1300819380'
+    end
+  end
+
   context 'when not signed nor encrypted' do
     it do
       jwt.to_s.should == no_signed


### PR DESCRIPTION
I was surprised when I was using a frozen hash (in specs) as claims that I was getting a `FrozenError`. So re-arrange the initializer to modify `self` instead of the passed in `claims`.